### PR TITLE
Optimism L2 - bridge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,9 @@
 [submodule "vendor/OpenZeppelin/openzeppelin-contracts"]
 	path = vendor/OpenZeppelin/openzeppelin-contracts
 	url = git@github.com:OpenZeppelin/openzeppelin-contracts.git
+[submodule "vendor/OpenZeppelin/openzeppelin-contracts-upgradeable"]
+	path = vendor/OpenZeppelin/openzeppelin-contracts-upgradeable
+	url = git@github.com:OpenZeppelin/openzeppelin-contracts-upgradeable.git
+[submodule "vendor/ethereum-optimism/optimism"]
+	path = vendor/ethereum-optimism/optimism
+	url = git@github.com:ethereum-optimism/optimism.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Optimism L2 bridge support
 - Access controlled mintable & burnable LinkToken, for use on sidechains and L2 networks.
 - Added versioning to v0.6 & v0.7 contracts
 

--- a/contracts/v0.7/bridge/README.md
+++ b/contracts/v0.7/bridge/README.md
@@ -1,3 +1,15 @@
 # LINK Token Bridge v0.7
 
 - `./token/LinkTokenChild.sol`: A mintable & burnable child LinkToken contract to be used on child networks.
+
+## Optimism L2 bridge
+
+The Optimistic Virtual Machine (OVM) is a scalable form of the EVM. Optimistic Rollup, by [Optimism](https://optimism.io), is the core scaling solution which enables the off-chain OVM to achieve cheap, instant transactions that still inherit L1 security. The OVM is an EVM-based VM which supports optimistically executing EVM smart contracts on a layer 1 blockchain like Ethereum. It is structured in such a way that it is possible to verify individual steps of its computation on Ethereum mainnet. This allows the mainnet to enforce validity of state roots with fraud proofs in the layer 2 Optimistic Rollup chain. For more information consult the [Optimism developer documentation](https://community.optimism.io/docs/).
+
+The set of contracts needed for the Optimism L2 LinkToken bridge can be found in the [./optimism](./optimism) dir.
+
+- `./optimism/OVM_EOACodeHashSet.sol`: Abstract helper contract used to keep track of OVM EOA contract set (OVM specific)
+- `./optimism/OVM_L1ERC20Gateway.sol`: Contract which stores deposited L1 funds that are in use on L2, and unlocks/transfers L1 funds on withdrawal. It synchronizes a corresponding L2 ERC20 Gateway, informing it of deposits, and listening to it for newly finalized withdrawals. (delegate proxy deployment)
+- `./optimism/OVM_L2ERC20Gateway.sol`: Contract which mints deposited L2 funds that are locked on L1, and burns L2 funds on withdrawal. It synchronizes a corresponding L1 ERC20 Gateway, informing it of withdrawals, and listening to it for newly finalized deposits. (delegate proxy deployment)
+
+These contracts are an implementation of [abstracts bridge contracts provided by Optimism](https://github.com/ethereum-optimism/optimism/tree/master/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens).

--- a/contracts/v0.7/bridge/mocks/ERC677CallerMock.sol
+++ b/contracts/v0.7/bridge/mocks/ERC677CallerMock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+
+/* Interface Imports */
+import { IERC677 } from "../../../v0.6/token/IERC677.sol";
+
+contract ERC677CallerMock {
+  /// @dev Forward transferAndCall to destination contract
+  function callTransferAndCall(
+    address destintion,
+    address to,
+    uint value,
+    bytes memory data
+  )
+    external
+  {
+    IERC677(destintion).transferAndCall(to, value, data);
+  }
+}

--- a/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.6.0 <0.8.0;
 
+/* Interface Imports */
+import { ITypeAndVersion } from "../../../v0.6/ITypeAndVersion.sol";
+
 /* Library Imports */
 import { EnumerableSet } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/utils/EnumerableSet.sol";
 
@@ -19,7 +22,7 @@ import { OwnableUpgradeable } from "../../../../vendor/OpenZeppelin/openzeppelin
  * As the OVM_ProxyEOA.sol contract source could potentially change in the future (i.e., due to a fork),
  * here we actually track a set of possible EOA proxy contracts.
  */
-abstract contract OVM_EOACodeHashSet is /* Initializable, */ OwnableUpgradeable {
+abstract contract OVM_EOACodeHashSet is ITypeAndVersion, /* Initializable, */ OwnableUpgradeable {
   // Add the EnumerableSet library
   using EnumerableSet for EnumerableSet.Bytes32Set;
 
@@ -34,13 +37,30 @@ abstract contract OVM_EOACodeHashSet is /* Initializable, */ OwnableUpgradeable 
   // Optimism v0.3.0-rc
   bytes32 constant OVM_EOA_CODE_HASH_V4 = 0xef2ab076db773ffc554c9f287134123439a5228e92f5b3194a28fec0a0afafe3;
 
+  /**
+   * @notice versions:
+   *
+   * - OVM_EOACodeHashSet 0.0.1: initial release
+   *
+   * @inheritdoc ITypeAndVersion
+   */
+  function typeAndVersion()
+    external
+    pure
+    override
+    virtual
+    returns (string memory)
+  {
+    return "OVM_EOACodeHashSet 0.0.1";
+  }
+
   function __OVM_EOACodeHashSet_init()
     internal
     initializer()
   {
-      __Context_init_unchained();
-      __Ownable_init_unchained();
-      __OVM_EOACodeHashSet_init_unchained();
+    __Context_init_unchained();
+    __Ownable_init_unchained();
+    __OVM_EOACodeHashSet_init_unchained();
   }
 
   /// @notice Adds genesis OVM_ProxyEOA.sol EXTCODEHASH to the default set.

--- a/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+
+/* Library Imports */
+import { EnumerableSet } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/utils/EnumerableSet.sol";
+
+/* Contract Imports */
+import { Initializable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/proxy/Initializable.sol";
+import { OwnableUpgradeable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+
+/**
+ * @dev Abstract helper contract used to keep track of OVM EOA contract set (OVM specific)
+ *
+ * The OVM implements a basic form of account abstraction. In effect, this means
+ * that the only type of account is a smart contract (no EOAs), and all user wallets
+ * are in fact smart contract wallets. So to check for EOA, we need to actually check if
+ * the sender is an OVM_ProxyEOA contract, which gets deployed by the ovmCREATEEOA opcode.
+ *
+ * As the OVM_ProxyEOA.sol contract source could potentially change in the future (i.e., due to a fork),
+ * here we actually track a set of possible EOA proxy contracts.
+ */
+abstract contract OVM_EOACodeHashSet is /* Initializable, */ OwnableUpgradeable {
+  // Add the EnumerableSet library
+  using EnumerableSet for EnumerableSet.Bytes32Set;
+
+  // Declare a Bytes32Set of code hashes
+  EnumerableSet.Bytes32Set private s_codeHasheSet;
+
+  // Declare the genesis OVM_ProxyEOA.sol EXTCODEHASH
+  bytes32 constant OVM_EOA_CODE_HASH_V0 = 0x93bb081a7dd92bde63b4d0aa9b8612352b2ec585176a80efc0a2a277ecfc010e;
+  bytes32 constant OVM_EOA_CODE_HASH_V1 = 0x8b4ea2cb36c232a7bab9d385b7054ff04752ec4c0fad5dc2ed4b1c18d982154c;
+  bytes32 constant OVM_EOA_CODE_HASH_V2 = 0xb6268ee2707994607682cc0e3b288cdd71acc63df8de0e6baa39a31a2b91d0ad;
+  bytes32 constant OVM_EOA_CODE_HASH_V3 = 0x93fae832274ff6aa942fa0c287fc0d8fe180f26b36c92e83d9be7e39309d3464;
+  // Optimism v0.3.0-rc
+  bytes32 constant OVM_EOA_CODE_HASH_V4 = 0xef2ab076db773ffc554c9f287134123439a5228e92f5b3194a28fec0a0afafe3;
+
+  function __OVM_EOACodeHashSet_init()
+    internal
+    initializer()
+  {
+      __Context_init_unchained();
+      __Ownable_init_unchained();
+      __OVM_EOACodeHashSet_init_unchained();
+  }
+
+  /// @notice Adds genesis OVM_ProxyEOA.sol EXTCODEHASH to the default set.
+  function __OVM_EOACodeHashSet_init_unchained()
+    internal
+    initializer()
+  {
+    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V0);
+    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V1);
+    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V2);
+    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V3);
+    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V4);
+  }
+
+  /// @notice Reverts if called by anyone other than whitelisted EOA contracts.
+  modifier onlyEOAContract() {
+    require(_isEOAContract(msg.sender), "Only callable by whitelisted EOA");
+    _;
+  }
+
+  /**
+   * @dev Returns true if the EOA contract code hash value is in the set. O(1).
+   * 
+   * @param value EOA contract code hash to check
+   */
+  function containsEOACodeHash(
+    bytes32 value
+  )
+    public
+    view
+    returns (bool)
+  {
+    return s_codeHasheSet.contains(value);
+  }
+
+  /**
+   * @dev Adds a EOA contract code hash value to the set. O(1).
+   * 
+   * Returns true if the value was added to the set, that is if it was not already present.
+   * @param value EOA contract code hash to add
+   */
+  function addEOACodeHash(
+    bytes32 value
+  )
+    public
+    onlyOwner()
+    returns (bool)
+  {
+    return s_codeHasheSet.add(value);
+  }
+
+  /**
+   * @dev Removes a EOA contract code hash value from the set. O(1).
+   * 
+   * Returns true if the value was removed from the set, that is if it was present.
+   * @param value EOA contract code hash to remove
+   */
+  function removeEOACodeHash(
+    bytes32 value
+  )
+    public
+    onlyOwner()
+    returns (bool)
+  {
+    return s_codeHasheSet.remove(value);
+  }
+
+  /**
+   * @dev Returns true if `account` is a whitelisted EOA contract.
+   * @param account Address to check
+   */
+  function _isEOAContract(
+    address account
+  )
+    internal
+    view
+    returns (bool)
+  {
+    bytes32 codehash;
+    // solhint-disable-next-line no-inline-assembly
+    assembly { codehash := extcodehash(account) }
+    return s_codeHasheSet.contains(codehash);
+  }
+}

--- a/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_EOACodeHashSet.sol
@@ -22,9 +22,12 @@ import { OwnableUpgradeable } from "../../../../vendor/OpenZeppelin/openzeppelin
  * As the OVM_ProxyEOA.sol contract source could potentially change in the future (i.e., due to a fork),
  * here we actually track a set of possible EOA proxy contracts.
  */
-abstract contract OVM_EOACodeHashSet is ITypeAndVersion, /* Initializable, */ OwnableUpgradeable {
+abstract contract OVM_EOACodeHashSet is ITypeAndVersion, Initializable, OwnableUpgradeable {
   // Add the EnumerableSet library
   using EnumerableSet for EnumerableSet.Bytes32Set;
+
+  event OVM_EOACodeHashAdded(bytes32 indexed value);
+  event OVM_EOACodeHashRemoved(bytes32 indexed value);
 
   // Declare a Bytes32Set of code hashes
   EnumerableSet.Bytes32Set private s_codeHasheSet;
@@ -68,11 +71,11 @@ abstract contract OVM_EOACodeHashSet is ITypeAndVersion, /* Initializable, */ Ow
     internal
     initializer()
   {
-    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V0);
-    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V1);
-    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V2);
-    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V3);
-    s_codeHasheSet.add(OVM_EOA_CODE_HASH_V4);
+    addEOACodeHash(OVM_EOA_CODE_HASH_V0);
+    addEOACodeHash(OVM_EOA_CODE_HASH_V1);
+    addEOACodeHash(OVM_EOA_CODE_HASH_V2);
+    addEOACodeHash(OVM_EOA_CODE_HASH_V3);
+    addEOACodeHash(OVM_EOA_CODE_HASH_V4);
   }
 
   /// @notice Reverts if called by anyone other than whitelisted EOA contracts.
@@ -109,6 +112,7 @@ abstract contract OVM_EOACodeHashSet is ITypeAndVersion, /* Initializable, */ Ow
     onlyOwner()
     returns (bool)
   {
+    emit OVM_EOACodeHashAdded(value);
     return s_codeHasheSet.add(value);
   }
 
@@ -125,6 +129,7 @@ abstract contract OVM_EOACodeHashSet is ITypeAndVersion, /* Initializable, */ Ow
     onlyOwner()
     returns (bool)
   {
+    emit OVM_EOACodeHashRemoved(value);
     return s_codeHasheSet.remove(value);
   }
 

--- a/contracts/v0.7/bridge/optimism/OVM_L1ERC20Gateway.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_L1ERC20Gateway.sol
@@ -4,6 +4,7 @@ pragma solidity >0.6.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
 /* Interface Imports */
+import { ITypeAndVersion } from "../../../v0.6/ITypeAndVersion.sol";
 import { IERC20 } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { IERC677Receiver } from "../../../v0.6/token/IERC677Receiver.sol";
 
@@ -28,7 +29,7 @@ import { Abs_L1TokenGateway } from "../../../../vendor/ethereum-optimism/optimis
  * Compiler used: solc
  * Runtime target: EVM
  */
-contract OVM_L1ERC20Gateway is IERC677Receiver, Initializable, Abs_L1TokenGateway {
+contract OVM_L1ERC20Gateway is ITypeAndVersion, IERC677Receiver, Initializable, Abs_L1TokenGateway {
   // L1 token we are bridging to L2
   IERC20 public s_l1ERC20;
 
@@ -40,6 +41,23 @@ contract OVM_L1ERC20Gateway is IERC677Receiver, Initializable, Abs_L1TokenGatewa
     )
     public
   {}
+
+  /**
+   * @notice versions:
+   *
+   * - OVM_L1ERC20Gateway 0.0.1: initial release
+   *
+   * @inheritdoc ITypeAndVersion
+   */
+  function typeAndVersion()
+    external
+    pure
+    override
+    virtual
+    returns (string memory)
+  {
+    return "OVM_L1ERC20Gateway 0.0.1";
+  }
 
   /**
    * @param l2ERC20Gateway L2 Gateway address on the chain being deposited into

--- a/contracts/v0.7/bridge/optimism/OVM_L1ERC20Gateway.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_L1ERC20Gateway.sol
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+// @unsupported: ovm
+pragma solidity >0.6.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+/* Interface Imports */
+import { IERC20 } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { IERC677Receiver } from "../../../v0.6/token/IERC677Receiver.sol";
+
+/* Library Imports */
+import { AddressUpgradeable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/utils/AddressUpgradeable.sol";
+
+/* Contract Imports */
+import { Initializable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/proxy/Initializable.sol";
+import { Abs_L1TokenGateway } from "../../../../vendor/ethereum-optimism/optimism/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol";
+
+/**
+ * @title OVM_L1ERC20Gateway
+ * @dev The L1 ERC20 Gateway is a contract which stores deposited L1 funds that are in use on L2.
+ * It synchronizes a corresponding L2 ERC20 Gateway, informing it of deposits, and listening to it
+ * for newly finalized withdrawals.
+ *
+ * NOTE: This contract extends Abs_L1TokenGateway, which is where we
+ * takes care of most of the initialization and the cross-chain logic.
+ * If you are looking to implement your own deposit/withdrawal contracts, you
+ * may also want to extend the abstract contract in a similar manner.
+ *
+ * Compiler used: solc
+ * Runtime target: EVM
+ */
+contract OVM_L1ERC20Gateway is IERC677Receiver, Initializable, Abs_L1TokenGateway {
+  // L1 token we are bridging to L2
+  IERC20 public s_l1ERC20;
+
+  /// @dev This contract lives behind a proxy, so the constructor parameters will go unused.
+  constructor()
+    Abs_L1TokenGateway(
+      address(0), // _l2DepositedToken
+      address(0) // _l1messenger
+    )
+    public
+  {}
+
+  /**
+   * @param l2ERC20Gateway L2 Gateway address on the chain being deposited into
+   * @param l1Messenger Cross-domain messenger used by this contract.
+   * @param l1ERC20 L1 ERC20 address this contract stores deposits for
+   */
+  function initialize(
+    address l2ERC20Gateway,
+    address l1Messenger,
+    address l1ERC20
+  )
+    public
+    virtual
+    initializer()
+  {
+    __OVM_L1ERC20Gateway_init(l2ERC20Gateway, l1Messenger, l1ERC20);
+  }
+
+  /**
+   * @param l2ERC20Gateway L2 Gateway address on the chain being deposited into
+   * @param l1Messenger Cross-domain messenger used by this contract.
+   * @param l1ERC20 L1 ERC20 address this contract stores deposits for
+   */
+  function __OVM_L1ERC20Gateway_init(
+    address l2ERC20Gateway,
+    address l1Messenger,
+    address l1ERC20
+  )
+    internal
+    initializer()
+  {
+    // Init parent contracts
+    require(l2ERC20Gateway != address(0), "Init to zero address");
+    require(l1Messenger != address(0), "Init to zero address");
+
+    l2DepositedToken = l2ERC20Gateway;
+    messenger = l1Messenger;
+
+    __OVM_L1ERC20Gateway_init_unchained(l1ERC20);
+  }
+
+  /**
+   * @param l1ERC20 L1 ERC20 address this contract stores deposits for
+   */
+  function __OVM_L1ERC20Gateway_init_unchained(
+    address l1ERC20
+  )
+    internal
+    initializer()
+  {
+    require(l1ERC20 != address(0), "Init to zero address");
+    s_l1ERC20 = IERC20(l1ERC20);
+  }
+
+  /// @dev Modifier requiring the contract to be initialized
+  modifier onlyInitialized() {
+    require(address(l2DepositedToken) != address(0), "Contract not initialized");
+    _;
+  }
+
+  /// @dev Modifier requiring sender to be EOA
+  modifier onlyEOA(address acc) {
+    // Used to stop withdrawals to contracts (avoid accidentally lost tokens)
+    require(!AddressUpgradeable.isContract(acc), "Account not EOA");
+    _;
+  }
+
+  /// @dev Returns L2 ERC20 Gateway address (AKA l2DepositedToken).
+  function l2ERC20Gateway()
+    public
+    view
+    returns (address)
+  {
+    // Default Optimism ERC20 bridge implemenation combines the L2 gateway and token
+    // into a single OVM_L2DepositedERC20 contract. From the perspective of L1 gateway,
+    // this should be just an implementation detail, so here we expose an address in a
+    // different more general name "l2ERC20Gateway".
+    return l2DepositedToken;
+  }
+
+  /**
+   * @dev Hook on successful token transfer that initializes deposit
+   * @notice Avoids two step approve/transferFrom, only accessible by EOA sender via ERC677 transferAndCall.
+   * @inheritdoc IERC677Receiver
+   */
+  function onTokenTransfer(
+    address _sender,
+    uint _value,
+    bytes memory /* _data */
+  )
+    external
+    override
+    onlyEOA(_sender)
+  {
+    require(msg.sender == address(s_l1ERC20), "onTokenTransfer sender not valid");
+    _initiateDeposit(_sender, _sender, _value);
+  }
+
+  /**
+   * @notice Only accessible by EOA sender.
+   * @inheritdoc Abs_L1TokenGateway
+   */
+  function deposit(
+    uint _amount
+  )
+    external
+    override
+    onlyEOA(msg.sender)
+  {
+    _initiateDeposit(msg.sender, msg.sender, _amount);
+  }
+
+  /**
+   * @notice Recipient account must be EOA.
+   * @inheritdoc Abs_L1TokenGateway
+   */
+  function depositTo(
+    address _to,
+    uint _amount
+  )
+    external
+    override
+    onlyEOA(_to)
+  {
+    _initiateDeposit(msg.sender, _to, _amount);
+  }
+
+  /**
+   * @dev deposit an amount of ERC20 to a recipients's balance on L2
+   * WARNING: This is a potentially unsafe operation that could end up with lost tokens,
+   * if tokens are sent to a contract. Be careful!
+   *
+   * @param _to L2 address to credit the withdrawal to
+   * @param _amount Amount of the ERC20 to deposit
+   */
+  function depositToUnsafe(
+    address _to,
+    uint _amount
+  )
+    external
+  {
+    _initiateDeposit(msg.sender, _to, _amount);
+  }
+
+  /**
+   * @dev When a deposit is initiated on L1, the L1 Gateway
+   * transfers the funds to itself for future withdrawals
+   *
+   * @param _from L1 address ERC20 is being deposited from
+   * @param _to L2 address that the ERC20 is being deposited to
+   * @param _amount Amount of ERC20 to send
+   */
+  function _handleInitiateDeposit(
+    address _from,
+    address _to,
+    uint256 _amount
+  )
+    internal
+    override
+    onlyInitialized()
+  {
+    // Funds already transfered via trasferAndCall (skipping)
+    if (msg.sender == address(s_l1ERC20)) return;
+
+    // Hold on to the newly deposited funds (must be approved)
+    s_l1ERC20.transferFrom(
+      _from,
+      address(this),
+      _amount
+    );
+  }
+
+  /**
+   * @dev When a withdrawal is finalized on L1, the L1 Gateway
+   * transfers the funds to the withdrawer
+   *
+   * @param _to L1 address that the ERC20 is being withdrawn to
+   * @param _amount Amount of ERC20 to send
+   */
+  function _handleFinalizeWithdrawal(
+    address _to,
+    uint _amount
+  )
+    internal
+    override
+    onlyInitialized()
+  {
+    // Transfer withdrawn funds out to withdrawer
+    s_l1ERC20.transfer(_to, _amount);
+  }
+}

--- a/contracts/v0.7/bridge/optimism/OVM_L2ERC20Gateway.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_L2ERC20Gateway.sol
@@ -3,6 +3,7 @@ pragma solidity >0.6.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
 /* Interface Imports */
+import { ITypeAndVersion } from "../../../v0.6/ITypeAndVersion.sol";
 import { IERC20Child } from "../token/IERC20Child.sol";
 import { IERC677Receiver } from "../../../v0.6/token/IERC677Receiver.sol";
 
@@ -24,7 +25,7 @@ import { OVM_EOACodeHashSet } from "./OVM_EOACodeHashSet.sol";
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
-contract OVM_L2ERC20Gateway is IERC677Receiver, /* Initializable, */ OVM_EOACodeHashSet, Abs_L2DepositedToken {
+contract OVM_L2ERC20Gateway is ITypeAndVersion, IERC677Receiver, /* Initializable, */ OVM_EOACodeHashSet, Abs_L2DepositedToken {
   // Bridged L2 token
   IERC20Child public s_l2ERC20;
 
@@ -35,6 +36,23 @@ contract OVM_L2ERC20Gateway is IERC677Receiver, /* Initializable, */ OVM_EOACode
     )
     public
   {}
+
+  /**
+   * @notice versions:
+   *
+   * - OVM_L2ERC20Gateway 0.0.1: initial release
+   *
+   * @inheritdoc ITypeAndVersion
+   */
+  function typeAndVersion()
+    external
+    pure
+    override(ITypeAndVersion, OVM_EOACodeHashSet)
+    virtual
+    returns (string memory)
+  {
+    return "OVM_L2ERC20Gateway 0.0.1";
+  }
 
   /**
    * @param l1ERC20Gateway L1 Gateway address on the chain being withdrawn into

--- a/contracts/v0.7/bridge/optimism/OVM_L2ERC20Gateway.sol
+++ b/contracts/v0.7/bridge/optimism/OVM_L2ERC20Gateway.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+/* Interface Imports */
+import { IERC20Child } from "../token/IERC20Child.sol";
+import { IERC677Receiver } from "../../../v0.6/token/IERC677Receiver.sol";
+
+/* Library Imports */
+import { AddressUpgradeable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/utils/AddressUpgradeable.sol";
+
+/* Contract Imports */
+import { Initializable } from "../../../../vendor/OpenZeppelin/openzeppelin-contracts-upgradeable/contracts/proxy/Initializable.sol";
+import { iOVM_L1TokenGateway } from "../../../../vendor/ethereum-optimism/optimism/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol";
+import { Abs_L2DepositedToken } from "../../../../vendor/ethereum-optimism/optimism/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol";
+import { OVM_EOACodeHashSet } from "./OVM_EOACodeHashSet.sol";
+
+/**
+ * @title OVM_L2ERC20Gateway
+ * @dev The L2 Deposited LinkToken is an token implementation which represents L1 assets deposited into L2.
+ * This contract mints new tokens when it hears about deposits into the L1 token gateway.
+ * This contract also burns the tokens intended for withdrawal, informing the L1 gateway to release L1 funds.
+ *
+ * Compiler used: optimistic-solc
+ * Runtime target: OVM
+ */
+contract OVM_L2ERC20Gateway is IERC677Receiver, /* Initializable, */ OVM_EOACodeHashSet, Abs_L2DepositedToken {
+  // Bridged L2 token
+  IERC20Child public s_l2ERC20;
+
+  /// @dev This contract lives behind a proxy, so the constructor parameters will go unused.
+  constructor()
+    Abs_L2DepositedToken(
+      address(0) // _l2CrossDomainMessenger
+    )
+    public
+  {}
+
+  /**
+   * @param l1ERC20Gateway L1 Gateway address on the chain being withdrawn into
+   * @param l2Messenger Cross-domain messenger used by this contract.
+   * @param l2ERC20 L2 ERC20 address this contract deposits for
+   */
+  function initialize(
+    address l1ERC20Gateway,
+    address l2Messenger,
+    address l2ERC20
+  )
+    public
+    virtual
+    initializer()
+  {
+    __OVM_L2ERC20Gateway_init(l1ERC20Gateway, l2Messenger, l2ERC20);
+  }
+
+  /**
+   * @param l1ERC20Gateway L1 Gateway address on the chain being withdrawn into
+   * @param l2Messenger Cross-domain messenger used by this contract.
+   * @param l2ERC20 L2 ERC20 address this contract deposits for
+   */
+  function __OVM_L2ERC20Gateway_init(
+    address l1ERC20Gateway,
+    address l2Messenger,
+    address l2ERC20
+  )
+    internal
+    initializer()
+  {
+    __Context_init_unchained();
+    __Ownable_init_unchained();
+
+    // Init parent contracts
+    require(l1ERC20Gateway != address(0), "Init to zero address");
+    require(l2Messenger != address(0), "Init to zero address");
+    // Abs_L2DepositedToken
+    init(iOVM_L1TokenGateway(l1ERC20Gateway));
+    // OVM_CrossDomainEnabled
+    messenger = l2Messenger;
+
+    __OVM_EOACodeHashSet_init_unchained();
+    __OVM_L2ERC20Gateway_init_unchained(l2ERC20);
+  }
+
+  /**
+   * @param l2ERC20 L2 ERC20 address this contract deposits for
+   */
+  function __OVM_L2ERC20Gateway_init_unchained(
+    address l2ERC20
+  )
+    internal
+    initializer()
+  {
+    require(l2ERC20 != address(0), "Init to zero address");
+    s_l2ERC20 = IERC20Child(l2ERC20);
+  }
+
+  /// @dev Modifier requiring sender to be EOA
+  modifier onlyEOA(address acc) {
+    // Used to stop withdrawals to contracts (avoid accidentally lost tokens)
+    require(!AddressUpgradeable.isContract(acc) || _isEOAContract(acc), "Account not EOA");
+    _;
+  }
+
+  /**
+   * @dev Hook on successful token transfer that initializes withdrawal
+   * @notice Avoids two step approve/transferFrom, only accessible by EOA sender via ERC677 transferAndCall.
+   * @inheritdoc IERC677Receiver
+   */
+  function onTokenTransfer(
+    address _sender,
+    uint _value,
+    bytes memory /* _data */
+  )
+    external
+    override
+    onlyEOA(_sender)
+  {
+    require(msg.sender == address(s_l2ERC20), "onTokenTransfer sender not valid");
+    _initiateWithdrawal(_sender, _value);
+  }
+
+  /**
+   * @notice Only accessible by EOA sender.
+   * @inheritdoc Abs_L2DepositedToken
+   */
+  function withdraw(
+    uint _amount
+  )
+    external
+    override
+    onlyEOA(msg.sender)
+  {
+    _initiateWithdrawal(msg.sender, _amount);
+  }
+
+  /**
+   * @notice Recipient account must be EOA.
+   * @inheritdoc Abs_L2DepositedToken
+   */
+  function withdrawTo(
+    address _to,
+    uint _amount
+  )
+    external
+    override
+    onlyEOA(_to)
+  {
+    _initiateWithdrawal(_to, _amount);
+  }
+
+  /**
+   * @dev initiate a withdraw of some token to a recipient's account on L1
+   * WARNING: This is a potentially unsafe operation that could end up with lost tokens,
+   * if tokens are sent to a contract. Be careful!
+   *
+   * @param _to L1 adress to credit the withdrawal to
+   * @param _amount Amount of the token to withdraw
+   */
+  function withdrawToUnsafe(
+    address _to,
+    uint _amount
+  )
+    external
+  {
+    _initiateWithdrawal(_to, _amount);
+  }
+
+  /**
+   * @dev When a withdrawal is initiated, we burn the funds to prevent subsequent L2 usage.
+   * @inheritdoc Abs_L2DepositedToken
+   */
+  function _handleInitiateWithdrawal(
+    address _to,
+    uint _amount
+  )
+    internal
+    override
+    onlyInitialized()
+  {
+    // Check if funds already transfered via trasferAndCall (skipping)
+    if (msg.sender != address(s_l2ERC20)) {
+      // Take the newly deposited funds (must be approved)
+      s_l2ERC20.transferFrom(
+        msg.sender,
+        address(this),
+        _amount
+      );
+    }
+
+    // And withdraw them to L1 (burn on L2)
+    s_l2ERC20.burn(_amount);
+  }
+
+  /**
+   * @dev When a deposit is finalized, we credit the account on L2 with the same amount of tokens.
+   * @inheritdoc Abs_L2DepositedToken
+   */
+  function _handleFinalizeDeposit(
+    address _to,
+    uint _amount
+  )
+    internal
+    override
+    onlyInitialized()
+  {
+    s_l2ERC20.mint(_to, _amount);
+  }
+}

--- a/contracts/v0.7/mocks/bridge/optimism/OVM_CrossDomainMessengerMock.sol
+++ b/contracts/v0.7/mocks/bridge/optimism/OVM_CrossDomainMessengerMock.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+
+/**
+ * @title OVM_CrossDomainMessengerMock
+ *
+ * Compiler used: optimistic-solc
+ * Runtime target: OVM
+ */
+contract OVM_CrossDomainMessengerMock {
+
+  /**
+   * Sends a cross domain message to the target messenger.
+   * @param _target Target contract address.
+   * @param _message Message to send to the target.
+   * @param _gasLimit Gas limit for the provided message.
+   */
+  function sendMessage(
+    address _target,
+    bytes memory _message,
+    uint32 _gasLimit
+  )
+    public
+  {
+    // noop
+  }
+}

--- a/contracts/v0.7/vendor/@openzeppelin/contracts/proxy/ProxyAdmin.sol
+++ b/contracts/v0.7/vendor/@openzeppelin/contracts/proxy/ProxyAdmin.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+
+import { ProxyAdmin as OZ_ProxyAdmin } from "../../../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/proxy/ProxyAdmin.sol";
+
+/**
+ * @dev This is an auxiliary contract meant to be assigned as the admin of a {TransparentUpgradeableProxy}.
+ *
+ * We force the toolchain to compile an external contract, by bringing in into our codebase like this.
+ * For more information see the parent OZ {ProxyAdmin} contract.
+ */
+contract ProxyAdmin is OZ_ProxyAdmin {}

--- a/contracts/v0.7/vendor/@openzeppelin/contracts/proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/v0.7/vendor/@openzeppelin/contracts/proxy/TransparentUpgradeableProxy.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.0 <0.8.0;
+
+import { TransparentUpgradeableProxy as OZ_TransparentUpgradeableProxy } from "../../../../../../vendor/OpenZeppelin/openzeppelin-contracts/contracts/proxy/TransparentUpgradeableProxy.sol";
+
+/**
+ * @dev This contract implements a proxy that is upgradeable by an admin.
+ *
+ * We force the toolchain to compile an external contract, by bringing in into our codebase like this.
+ * For more information see the parent OZ {TransparentUpgradeableProxy} contract.
+ */
+contract TransparentUpgradeableProxy is OZ_TransparentUpgradeableProxy {
+
+  /**
+   * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
+   * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
+   */
+  constructor(
+    address _logic,
+    address _admin,
+    bytes memory _data
+  )
+    public
+    payable
+    OZ_TransparentUpgradeableProxy(_logic, _admin, _data)
+  {}
+}

--- a/env/.env.kovan
+++ b/env/.env.kovan
@@ -3,3 +3,10 @@
 PRIVATE_KEY=
 L1_WEB3_URL=https://kovan.infura.io/v3/API_KEY
 L2_WEB3_URL=https://kovan.optimism.io
+
+# optional, will be deployed for us if unset
+L1_ERC20_ADDRESS=
+# optional, will be deployed for us if unset
+L1_ERC20_GATEWAY_ADDRESS=
+# optional, will be deployed for us if unset (and L1_ERC20_GATEWAY_ADDRESS unset)
+L2_ERC20_ADDRESS=

--- a/env/.env.local
+++ b/env/.env.local
@@ -2,3 +2,10 @@
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 L1_WEB3_URL=http://127.0.0.1:9545
 L2_WEB3_URL=http://127.0.0.1:8545
+
+# optional, will be deployed for us if unset
+L1_ERC20_ADDRESS=
+# optional, will be deployed for us if unset
+L1_ERC20_GATEWAY_ADDRESS=
+# optional, will be deployed for us if unset (and L1_ERC20_GATEWAY_ADDRESS unset)
+L2_ERC20_ADDRESS=

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "hardhat test --no-compile --show-stack-traces",
     "script:oe:up": "./node_modules/@chainlink/optimism-utils/scripts/run-ci.sh",
     "script:oe:down": "cd optimism/ops && docker-compose down -v",
-    "script:oe:clean": "cd optimism/ops && docker-compose down -v --remove-orphan --rmi all"
+    "script:oe:clean": "cd optimism/ops && docker-compose down -v --remove-orphan --rmi all",
+    "script:oe:deposit-withdraw": "ts-node scripts/deposit-withdraw.ts"
   },
   "dependencies": {},
   "devDependencies": {

--- a/scripts/deposit-withdraw.ts
+++ b/scripts/deposit-withdraw.ts
@@ -1,0 +1,223 @@
+import { Wallet, Contract } from 'ethers'
+import { BigNumberish } from '@ethersproject/bignumber'
+import { parseEther } from '@ethersproject/units'
+import { Direction, waitForXDomainTransaction } from '@chainlink/optimism-utils/dist/watcher-utils'
+import { hardhat, getContractFactory, deploy, optimism, Targets, Versions } from '../src'
+import * as h from '../test/helpers'
+
+export type ConfiguredBridge = {
+  l1ERC20: Contract
+  l1ERC20Gateway: Contract
+  l2ERC20: Contract
+  l2ERC20Gateway: Contract
+}
+
+export const setupOrRetrieveBridge = async (
+  l1Wallet: Wallet,
+  l2Wallet: Wallet,
+  l1MessengerAddr: string,
+  l2MessengerAddr: string,
+  l1ERC20Addr?: string,
+  l2ERC20Addr?: string,
+  l1ERC20GatewayAddr?: string,
+): Promise<ConfiguredBridge> => {
+  // Deploy or retrieve L1 ERC20
+  let l1ERC20: Contract
+  const l1ERC20__Factory = getContractFactory('LinkToken', l1Wallet, Versions.v0_6, Targets.EVM)
+  if (!l1ERC20Addr) {
+    console.log('No L1 ERC20 specified - deploying a new test L1 ERC20 (LinkToken).')
+    l1ERC20 = await deploy(l1ERC20__Factory, 'LinkToken (L1 ERC20)')
+  } else {
+    console.log('Connecting to an existing L1 ERC20 at:', l1ERC20Addr)
+    l1ERC20 = l1ERC20__Factory.attach(l1ERC20Addr)
+  }
+
+  // Deploy or retrieve L2 ERC20
+  let l2ERC20: Contract
+  const l2ERC20_Factory = getContractFactory('LinkTokenChild', l2Wallet, Versions.v0_7, Targets.OVM)
+  if (!l2ERC20Addr) {
+    console.log('No L2 ERC20 specified - deploying a new test L2 ERC20 (LinkTokenChild).')
+    l2ERC20 = await deploy(l2ERC20_Factory, 'LinkTokenChild (L2 ERC20)')
+  } else {
+    console.log('Connecting to an existing L2 ERC20 at:', l2ERC20Addr)
+    l2ERC20 = l2ERC20_Factory.attach(l2ERC20Addr)
+  }
+
+  let l1ERC20Gateway: Contract
+  let l2ERC20Gateway: Contract
+  if (!l1ERC20GatewayAddr) {
+    console.log('No L1 gateway specified, deploying a new L1-L2 bridge...')
+    ;({ l1ERC20Gateway, l2ERC20Gateway } = await optimism.deployGateways(
+      l1Wallet,
+      l2Wallet,
+      l1ERC20.address,
+      l2ERC20.address,
+      l1MessengerAddr,
+      l2MessengerAddr,
+    ))
+    // Grant the required access (gateway role)
+    console.log(`Adding access (gateway role) to OVM_L2ERC20Gateway at: ${l2ERC20Gateway.address}`)
+    const addAccessTx = await l2ERC20.addAccess(l2ERC20Gateway.address)
+    await addAccessTx.wait()
+  } else {
+    // Use the specified OVM_L1ERC20Gateway address to construct L1-L2 bridge
+    l1ERC20Gateway = getContractFactory(
+      'OVM_L1ERC20Gateway',
+      l1Wallet,
+      Versions.v0_7,
+      Targets.EVM,
+    ).attach(l1ERC20GatewayAddr)
+
+    const l2ERC20GatewayAddr = await l1ERC20Gateway.l2ERC20Gateway()
+    l2ERC20Gateway = getContractFactory(
+      'OVM_L2ERC20Gateway',
+      l2Wallet,
+      Versions.v0_7,
+      Targets.OVM,
+    ).attach(l2ERC20GatewayAddr)
+    // TODO: check l2ERC20.address matches
+
+    // Check role
+    const hasGatewayRole = await l2ERC20.hasAccess(l2ERC20Gateway.address, '')
+    if (!hasGatewayRole) {
+      throw Error(`OVM_L2ERC20Gateway should have access (gateway role)`)
+    }
+  }
+
+  // Configured bridge
+  const bridge = {
+    l1ERC20,
+    l1ERC20Gateway,
+    l2ERC20,
+    l2ERC20Gateway,
+  }
+  logBridge(bridge)
+  return bridge
+}
+
+export type CheckBalances = (
+  l1Wallet: Wallet,
+  l1ERC20: Contract,
+  l2Wallet: Wallet,
+  l2ERC20: Contract,
+) => Promise<void>
+
+export const depositAndWithdraw = async (
+  oe: optimism.env.OptimismEnv,
+  checkBalances: CheckBalances,
+  amount: BigNumberish = 1,
+  transferAndCall: boolean = false,
+) => {
+  // Grab existing addresses if specified
+  const l1ERC20Addr = process.env.L1_ERC20_ADDRESS
+  const l2ERC20Addr = process.env.L2_ERC20_ADDRESS
+  const l1ERC20GatewayAddr = process.env.L1_ERC20_GATEWAY_ADDRESS
+
+  const bridge = await setupOrRetrieveBridge(
+    oe.l1Wallet,
+    oe.l2Wallet,
+    oe.l1Messenger.address,
+    oe.l2Messenger.address,
+    l1ERC20Addr,
+    l2ERC20Addr,
+    l1ERC20GatewayAddr,
+  )
+
+  const _approve = transferAndCall
+    ? () => {} // no approve when using transferAndCall
+    : async (_token: Contract, _spenderAddr: string, _amount: BigNumberish) => {
+        console.log(`Approving spender: ${_spenderAddr} for ${_amount}`)
+        const approveTx = await _token.approve(_spenderAddr, _amount)
+        await approveTx.wait()
+        console.log('Approved: https://kovan.etherscan.io/tx/' + approveTx.hash)
+        console.log()
+      }
+
+  const _checkBalances = () =>
+    checkBalances(oe.l1Wallet, bridge.l1ERC20, oe.l2Wallet, bridge.l2ERC20)
+
+  const { watcher } = oe
+
+  await _checkBalances()
+
+  // Approve L1 Gateway
+  await _approve(bridge.l1ERC20, bridge.l1ERC20Gateway.address, amount)
+
+  // Deposit to L1 Gateway
+  console.log('Depositing into L1 gateway contract...')
+  const depositTx = transferAndCall
+    ? bridge.l1ERC20.transferAndCall(bridge.l1ERC20Gateway.address, amount, Buffer.from(''))
+    : bridge.l1ERC20Gateway.deposit(amount)
+  const receiptsDepositTx = await waitForXDomainTransaction(watcher, depositTx, Direction.L1ToL2)
+  console.log('Deposited: https://kovan.etherscan.io/tx/' + receiptsDepositTx.tx.hash)
+  console.log('Completed Deposit! L2 tx hash:', receiptsDepositTx.remoteTx.hash)
+
+  await _checkBalances()
+
+  // Approve L2 Gateway
+  await _approve(bridge.l2ERC20, bridge.l2ERC20Gateway.address, amount)
+
+  // Withdraw from L2 Gateway
+  console.log('Withdrawing from L2 gateway contract...')
+  const withdrawTx = transferAndCall
+    ? bridge.l2ERC20.transferAndCall(bridge.l2ERC20Gateway.address, amount, Buffer.from(''))
+    : bridge.l2ERC20Gateway.withdraw(amount)
+  const receiptsWithdrawTx = await waitForXDomainTransaction(watcher, withdrawTx, Direction.L2ToL1)
+  console.log('Withdrawal tx hash:' + receiptsWithdrawTx.tx.hash)
+  console.log('Completed Withdrawal! L1 tx hash:', receiptsWithdrawTx.remoteTx.hash)
+
+  await _checkBalances()
+}
+
+const logBalances: CheckBalances = async (l1Wallet, l1ERC20, l2Wallet, l2ERC20) => {
+  console.log()
+  console.log('Checking balances: ')
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  if (l1ERC20) {
+    const l1Balance = await l1ERC20.balanceOf(l1Wallet.address)
+    console.log('L1 balance of', l1Wallet.address, 'is', l1Balance.toString())
+  } else {
+    console.log('L1 ERC20 NOT configured')
+  }
+  if (l2ERC20) {
+    const l2Balance = await l2ERC20.balanceOf(l2Wallet.address)
+    console.log('L2 balance of', l2Wallet.address, 'is', l2Balance.toString())
+  } else {
+    console.log('L2 ERC20 NOT configured')
+  }
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  console.log()
+}
+
+const logBridge = async (bridge: ConfiguredBridge) => {
+  console.log()
+  console.log('Full L1-L2 configured bridge: ')
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  console.log('L1 ERC20:         ', bridge.l1ERC20.address)
+  console.log('L1 ERC20 Gateway: ', bridge.l1ERC20Gateway.address)
+  console.log('L2 ERC20:         ', bridge.l2ERC20.address)
+  console.log('L2 ERC20 Gateway: ', bridge.l2ERC20Gateway.address)
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  console.log()
+}
+
+const _run = async () => {
+  // Load CLI arguments
+  const { argv } = hardhat.yargs
+    .env(false)
+    .string('network')
+    .number('amount')
+    .boolean('transferAndCall')
+  // Load the configuration from environment
+  const targetNetwork = argv.network || 'local'
+  const oe = await h.optimism.loadEnv(targetNetwork)
+  // Fund L2 wallet
+  await oe.depositL2(parseEther('1') as BigNumberish)
+  // Start scripts
+  await depositAndWithdraw(oe, logBalances, argv.amount || 1, argv.transferAndCall)
+}
+
+if (require.main === module) {
+  console.log('Running depositAndWithdraw script...')
+  _run().catch(console.error).finally(process.exit)
+}

--- a/src/optimism/index.ts
+++ b/src/optimism/index.ts
@@ -1,1 +1,68 @@
+import { Wallet, Contract, Signer } from 'ethers'
+import { getContractFactory, Targets, Versions } from '../'
+import { deploy, deployProxy } from '../contract-defs'
+
 export * from '@chainlink/optimism-utils'
+
+export const deployGateways = async (
+  l1Wallet: Wallet,
+  l2Wallet: Wallet,
+  l1ERC20Address: string,
+  l2ERC20Address: string,
+  l1MessengerAddress: string,
+  l2MessengerAddress: string,
+  isProxyDeployment = true,
+): Promise<{
+  l1ERC20Gateway: Contract
+  l2ERC20Gateway: Contract
+}> => {
+  // Deploy L2 ERC20 Gateway
+  const l2ERC20Gateway = await deployL2ERC20Gateway(l2Wallet, isProxyDeployment)
+
+  // Deploy & Init L1 ERC20 Gateway
+  const l1ERC20Gateway = await deployL1ERC20Gateway(l1Wallet, isProxyDeployment)
+
+  const l1InitPayload = [l2ERC20Gateway.address, l1MessengerAddress, l1ERC20Address]
+  const l1InitTx = await l1ERC20Gateway.initialize(...l1InitPayload)
+  await l1InitTx.wait()
+  console.log('OVM_L1ERC20Gateway initialized with:', l1InitPayload)
+
+  // Init L2 ERC20 Gateway
+  const l2InitPayload = [l1ERC20Gateway.address, l2MessengerAddress, l2ERC20Address]
+  const l2InitTx = await l2ERC20Gateway.initialize(...l2InitPayload)
+  await l2InitTx.wait()
+  console.log('OVM_L2ERC20Gateway initialized with:', l2InitPayload)
+
+  return {
+    l1ERC20Gateway,
+    l2ERC20Gateway,
+  }
+}
+
+export const deployL1ERC20Gateway = async (l1Signer: Signer, proxy: boolean = false) => {
+  // Deploy L1 ERC20 Gateway
+  const l1ERC20Gateway = await deploy(
+    getContractFactory('OVM_L1ERC20Gateway', l1Signer, Versions.v0_7, Targets.EVM),
+    'OVM_L1ERC20Gateway',
+  )
+
+  if (!proxy) return l1ERC20Gateway
+
+  // Deploy L2 ERC20 Gateway Proxy
+  const logic = l1ERC20Gateway
+  return (await deployProxy(l1Signer, Targets.EVM, logic)).proxy
+}
+
+export const deployL2ERC20Gateway = async (l2Signer: Signer, isProxyDeployment: boolean = false) => {
+  // Deploy L2 ERC20 Gateway
+  const l2ERC20Gateway = await deploy(
+    getContractFactory('OVM_L2ERC20Gateway', l2Signer, Versions.v0_7, Targets.OVM),
+    'OVM_L2ERC20Gateway',
+  )
+
+  if (!isProxyDeployment) return l2ERC20Gateway
+
+  // Deploy L2 ERC20 Gateway Proxy
+  const logic = l2ERC20Gateway
+  return (await deployProxy(l2Signer, Targets.OVM, logic)).proxy
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -4,12 +4,12 @@ import { hardhat, Networks, Versions } from '../../src'
 
 export * as optimism from './optimism'
 
-export const describes = {
+export const describes = () => ({
   // Only run if Hardhat unit test
   HH: !hardhat.argv.network || hardhat.argv.network === Networks.HARDHAT ? describe : describe.skip,
   // Only run if OE integration test
   OE: hardhat.argv.network === Networks.OPTIMISM ? describe : describe.skip,
-}
+})
 
 export const revertShim = (v?: Versions) =>
   v && v === Versions.v0_4 // reason string not supported on versions <= 0.4

--- a/test/v0.4/ERC677Token.test.ts
+++ b/test/v0.4/ERC677Token.test.ts
@@ -3,7 +3,7 @@ import { getContractFactory, Versions } from '../../src'
 import { shouldBehaveLikeERC677 } from '../behavior/ERC677'
 import * as h from '../helpers'
 
-h.describes.HH(`ERC677Token ${Versions.v0_4}`, () => {
+h.describes().HH(`ERC677Token ${Versions.v0_4}`, () => {
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(name, signer, Versions.v0_4)
 

--- a/test/v0.4/LinkToken.test.ts
+++ b/test/v0.4/LinkToken.test.ts
@@ -6,7 +6,7 @@ import * as h from '../helpers'
 
 const v4_EXTRA_PUBLIC_ABI: string[] = []
 
-h.describes.HH(`LinkToken ${Versions.v0_4}`, () => {
+h.describes().HH(`LinkToken ${Versions.v0_4}`, () => {
   const overrides: Record<string, string> = { Token677: 'LinkToken' }
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(overrides[name] || name, signer, Versions.v0_4)

--- a/test/v0.4/token/BasicToken.test.ts
+++ b/test/v0.4/token/BasicToken.test.ts
@@ -4,7 +4,7 @@ import { getContractFactory, Versions } from '../../../src'
 import { shouldBehaveLikeBasicToken } from '../../behavior/token/BasicToken'
 import * as h from '../../helpers'
 
-h.describes.HH(`BasicToken ${Versions.v0_4}`, () => {
+h.describes().HH(`BasicToken ${Versions.v0_4}`, () => {
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(name, signer, Versions.v0_4)
 

--- a/test/v0.4/token/StandardToken.test.ts
+++ b/test/v0.4/token/StandardToken.test.ts
@@ -5,7 +5,7 @@ import { shouldBehaveLikeBasicToken } from '../../behavior/token/BasicToken'
 import { shouldBehaveLikeStandardToken } from '../../behavior/token/StandardToken'
 import * as h from '../../helpers'
 
-h.describes.HH(`StandardToken ${Versions.v0_4}`, () => {
+h.describes().HH(`StandardToken ${Versions.v0_4}`, () => {
   const overrides: Record<string, string> = { BasicTokenMock: 'StandardTokenMock' }
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(overrides[name] || name, signer, Versions.v0_4)

--- a/test/v0.6/ERC677.test.ts
+++ b/test/v0.6/ERC677.test.ts
@@ -7,7 +7,7 @@ import { getContractFactory, Versions } from '../../src'
 import { shouldBehaveLikeERC677 } from '../behavior/ERC677'
 import * as h from '../helpers'
 
-h.describes.HH(`ERC677 ${Versions.v0_6}`, () => {
+h.describes().HH(`ERC677 ${Versions.v0_6}`, () => {
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(name, signer, Versions.v0_6)
 

--- a/test/v0.6/LinkToken.test.ts
+++ b/test/v0.6/LinkToken.test.ts
@@ -9,7 +9,7 @@ import * as h from '../helpers'
 
 const v6_EXTRA_PUBLIC_ABI = ['decreaseAllowance', 'increaseAllowance', 'typeAndVersion']
 
-h.describes.HH(`LinkToken ${Versions.v0_6}`, () => {
+h.describes().HH(`LinkToken ${Versions.v0_6}`, () => {
   const overrides: Record<string, string> = { Token677: 'LinkToken' }
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(overrides[name] || name, signer, Versions.v0_6)

--- a/test/v0.6/PegSwap.test.ts
+++ b/test/v0.6/PegSwap.test.ts
@@ -9,7 +9,7 @@ import { Token20__factory } from '../../build/types/v0.6/factories/Token20__fact
 
 import * as h from '../helpers'
 
-h.describes.HH('PegSwap', () => {
+h.describes().HH('PegSwap', () => {
   let swap: Contract,
     owner: SignerWithAddress,
     base: Contract,

--- a/test/v0.6/token/BasicToken.test.ts
+++ b/test/v0.6/token/BasicToken.test.ts
@@ -7,7 +7,7 @@ import { getContractFactory, Versions } from '../../../src'
 import { shouldBehaveLikeBasicToken } from '../../behavior/token/BasicToken'
 import * as h from '../../helpers'
 
-h.describes.HH(`BasicToken ${Versions.v0_6}`, () => {
+h.describes().HH(`BasicToken ${Versions.v0_6}`, () => {
   const overrides: Record<string, string> = { BasicTokenMock: 'Token20' }
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(overrides[name] || name, signer, Versions.v0_6)

--- a/test/v0.6/token/StandardToken.test.ts
+++ b/test/v0.6/token/StandardToken.test.ts
@@ -8,7 +8,7 @@ import { shouldBehaveLikeBasicToken } from '../../behavior/token/BasicToken'
 import { shouldBehaveLikeStandardToken } from '../../behavior/token/StandardToken'
 import * as h from '../../helpers'
 
-h.describes.HH(`StandardToken ${Versions.v0_6}`, () => {
+h.describes().HH(`StandardToken ${Versions.v0_6}`, () => {
   const overrides: Record<string, string> = { BasicTokenMock: 'Token20', StandardTokenMock: 'Token20' }
   const _getContractFactory = (name: string, signer?: Signer) =>
     getContractFactory(overrides[name] || name, signer, Versions.v0_6)

--- a/test/v0.7/bridge/optimism/OVM_L1ERC20Gateway.test.ts
+++ b/test/v0.7/bridge/optimism/OVM_L1ERC20Gateway.test.ts
@@ -1,0 +1,138 @@
+import { ethers } from 'hardhat'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { Versions, getContractFactory, Targets, optimism } from '../../../../src'
+import * as h from '../../../helpers'
+
+h.describes().HH(`OVM_L1ERC20Gateway ${Versions.v0_7}`, () => {
+  describe('deposit safety', () => {
+    let wallet: SignerWithAddress, walletOther: SignerWithAddress
+
+    before(async () => {
+      ;[wallet, walletOther] = await ethers.getSigners()
+    })
+
+    let l1Token: Contract, l1Gateway: Contract
+
+    beforeEach(async () => {
+      l1Token = await getContractFactory('LinkToken', wallet, Versions.v0_6, Targets.EVM).deploy()
+
+      const messengerMock = await getContractFactory(
+        'OVM_CrossDomainMessengerMock',
+        wallet,
+        Versions.v0_7,
+        Targets.EVM,
+      ).deploy()
+      const fake_l1CrossDomainMessenger = messengerMock.address
+      const fake_l2ERC20Gateway = '0x00000000000000000000000000000000000000ff'
+
+      l1Gateway = await optimism.deployL1ERC20Gateway(wallet)
+      // Init L2 ERC20 Gateways
+      const l1InitPayload = [fake_l2ERC20Gateway, fake_l1CrossDomainMessenger, l1Token.address]
+      const l1InitTx = await l1Gateway.initialize(...l1InitPayload)
+      await l1InitTx.wait()
+    })
+
+    it('can deposit (all fn) as EOA contract', async () => {
+      const totalAmount = '30'
+      await l1Token.approve(l1Gateway.address, totalAmount)
+
+      const amount = '10'
+      await l1Gateway.deposit(amount)
+      await l1Gateway.depositTo(wallet.address, amount)
+      await l1Gateway.depositToUnsafe(wallet.address, amount)
+
+      const balanceWallet = await l1Token.balanceOf(wallet.address)
+      expect(balanceWallet).to.equal('999999999999999999999999970')
+
+      const balanceGateway = await l1Token.balanceOf(l1Gateway.address)
+      expect(balanceGateway).to.equal(totalAmount)
+    })
+
+    it('can depositTo other account', async () => {
+      const totalAmount = '20'
+      await l1Token.approve(l1Gateway.address, totalAmount)
+
+      const amount = '10'
+      await l1Gateway.depositTo(walletOther.address, amount)
+      await l1Gateway.depositToUnsafe(walletOther.address, amount)
+
+      const balanceWallet = await l1Token.balanceOf(wallet.address)
+      expect(balanceWallet).to.equal('999999999999999999999999980')
+
+      const balanceGateway = await l1Token.balanceOf(l1Gateway.address)
+      expect(balanceGateway).to.equal(totalAmount)
+    })
+
+    it("can't depositTo contract", async () => {
+      const totalAmount = '10'
+      await l1Token.approve(l1Gateway.address, totalAmount)
+
+      const contractAddr = l1Token.address
+      const amount = totalAmount
+
+      await expect(l1Gateway.depositTo(contractAddr, amount)).to.be.revertedWith('Account not EOA')
+    })
+
+    it('can depositToUnsafe contract', async () => {
+      const totalAmount = '10'
+      await l1Token.approve(l1Gateway.address, totalAmount)
+
+      const contractAddr = l1Token.address
+      const amount = totalAmount
+      await l1Gateway.depositToUnsafe(contractAddr, amount)
+
+      const balanceWallet = await l1Token.balanceOf(wallet.address)
+      expect(balanceWallet).to.equal('999999999999999999999999990')
+
+      const balanceGateway = await l1Token.balanceOf(l1Gateway.address)
+      expect(balanceGateway).to.equal(totalAmount)
+    })
+
+    // TODO: refactor as reusable behavior
+    describe('ERC677Receiver', () => {
+      it('can transferAndCall from EOA', async () => {
+        // Skip approval
+        const totalAmount = '30'
+        const amount = '10'
+        await l1Token.transferAndCall(l1Gateway.address, amount, Buffer.from(''))
+        await l1Token.transferAndCall(l1Gateway.address, amount, Buffer.from(''))
+        await l1Token.transferAndCall(l1Gateway.address, amount, Buffer.from(''))
+
+        const balanceWallet = await l1Token.balanceOf(wallet.address)
+        expect(balanceWallet).to.equal('999999999999999999999999970')
+
+        const balanceGateway = await l1Token.balanceOf(l1Gateway.address)
+        expect(balanceGateway).to.equal(totalAmount)
+      })
+
+      it("can't transferAndCall from contract", async () => {
+        const erc677CallerMock = await getContractFactory(
+          'ERC677CallerMock',
+          wallet,
+          Versions.v0_7,
+          Targets.EVM,
+        ).deploy()
+
+        // Fund the mock contract
+        const amount = '10'
+        await l1Token.transfer(erc677CallerMock.address, amount)
+
+        // Mock contract tries (fails) to transferAndCall to L1 Gateway
+        const payload = [l1Token.address, l1Gateway.address, amount, Buffer.from('')]
+        await expect(erc677CallerMock.callTransferAndCall(...payload)).to.be.revertedWith(
+          'Account not EOA',
+        )
+      })
+
+      it("can't call onTokenTransfer directly", async () => {
+        const amount = '10'
+        const payload = [wallet.address, amount, Buffer.from('')]
+        await expect(l1Gateway.onTokenTransfer(...payload)).to.be.revertedWith(
+          'onTokenTransfer sender not valid',
+        )
+      })
+    })
+  })
+})

--- a/test/v0.7/bridge/optimism/OVM_L2ERC20Gateway.test.ts
+++ b/test/v0.7/bridge/optimism/OVM_L2ERC20Gateway.test.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai'
+import { Wallet, Contract, BigNumberish } from 'ethers'
+import { parseEther } from '@ethersproject/units'
+import { getContractFactory, deploy, Targets, Versions, optimism } from '../../../../src'
+import * as h from '../../../helpers'
+
+// short alias
+const _getFactory = getContractFactory
+
+describe(`OVM_L2ERC20Gateway ${Versions.v0_7}`, () => {
+  h.describes().OE(`@integration`, () => {
+    describe('withdrawal safety', () => {
+      let oe: optimism.env.OptimismEnv, l2Token: Contract, l2Gateway: Contract
+
+      before(async function () {
+        this.timeout(20000)
+
+        // Load the configuration from environment
+        oe = await h.optimism.loadEnv()
+        await oe.depositL2(parseEther('1') as BigNumberish)
+
+        // Deploy LinkTokenChild contract
+        l2Token = await deploy(
+          _getFactory('LinkTokenChild', oe.l2Wallet, Versions.v0_7, Targets.OVM),
+          'LinkTokenChild',
+        )
+
+        // Deploy l2CrossDomainMessenger
+        const messengerMock = await deploy(
+          _getFactory('OVM_CrossDomainMessengerMock', oe.l2Wallet, Versions.v0_7, Targets.OVM),
+          'OVM_CrossDomainMessengerMock',
+        )
+        const fake_l2CrossDomainMessenger = messengerMock.address
+
+        // Deploy l2Gateway with l2CrossDomainMessenger
+        l2Gateway = await deploy(
+          _getFactory('OVM_L2ERC20Gateway', oe.l2Wallet, Versions.v0_7, Targets.OVM),
+          'OVM_L2ERC20Gateway',
+        )
+
+        // Init L2 ERC20 Gateway
+        const fake_l1ERC20Gateway = '0x00000000000000000000000000000000000000ff'
+        const l2InitPayload = [fake_l1ERC20Gateway, fake_l2CrossDomainMessenger, l2Token.address]
+        const l2InitTx = await l2Gateway.initialize(...l2InitPayload)
+        await l2InitTx.wait()
+
+        // Grant access (gateway role)
+        const addAccessTx1 = await l2Token.addAccess(l2Gateway.address)
+        await addAccessTx1.wait()
+
+        // Mock deposit $$$
+        const addAccessTx2 = await l2Token.addAccess(oe.l2Wallet.address)
+        await addAccessTx2.wait()
+
+        const depositTx = await l2Token.mint(oe.l2Wallet.address, '1000000000000000000000000000')
+        await depositTx.wait()
+      })
+
+      it('can withdraw (all fn) as EOA contract', async () => {
+        const amountTotal = '30'
+        const approveTx = await l2Token.approve(l2Gateway.address, amountTotal)
+        await approveTx.wait()
+
+        const amount = '10'
+        const withdrawTx = await l2Gateway.withdraw(amount)
+        await withdrawTx.wait()
+
+        const withdrawToTx = await l2Gateway.withdrawTo(oe.l2Wallet.address, amount)
+        await withdrawToTx.wait()
+
+        const withdrawToUnsafeTx = await l2Gateway.withdrawToUnsafe(oe.l2Wallet.address, amount)
+        await withdrawToUnsafeTx.wait()
+
+        const balance = await l2Token.balanceOf(oe.l2Wallet.address)
+        expect(balance).to.equal('999999999999999999999999970')
+      }).timeout(20000)
+
+      it('can withdrawTo an empty (unseen) account', async () => {
+        const emptyAccPK = '0x' + '12345678'.repeat(8)
+        const emptyAccWallet = new Wallet(emptyAccPK, oe.l2Wallet.provider)
+
+        const amountTotal = '20'
+        const approveTx = await l2Token.approve(l2Gateway.address, amountTotal)
+        await approveTx.wait()
+
+        const amount = '10'
+        const withdrawToTx = await l2Gateway.withdrawTo(emptyAccWallet.address, amount)
+        await withdrawToTx.wait()
+
+        const withdrawToUnsafeTx = await l2Gateway.withdrawToUnsafe(emptyAccWallet.address, amount)
+        await withdrawToUnsafeTx.wait()
+
+        const balance = await l2Token.balanceOf(oe.l2Wallet.address)
+        expect(balance).to.equal('999999999999999999999999950')
+      }).timeout(10000)
+
+      it("can't withdrawTo contract", async () => {
+        const contractAddr = l2Token.address
+
+        const amount = '10'
+        const approveTx = await l2Token.approve(l2Gateway.address, amount)
+        await approveTx.wait()
+
+        const withdrawToTx = l2Gateway.withdrawTo(contractAddr, amount)
+        await expect(withdrawToTx).to.be.revertedWith('Account not EOA')
+      }).timeout(10000)
+
+      it('can withdrawToUnsafe contract', async () => {
+        const contractAddr = l2Token.address
+
+        const amount = '10'
+        const approveTx = await l2Token.approve(l2Gateway.address, amount)
+        await approveTx.wait()
+
+        const withdrawToUnsafeTx = await l2Gateway.withdrawToUnsafe(contractAddr, amount)
+        await withdrawToUnsafeTx.wait()
+
+        const balance = await l2Token.balanceOf(oe.l2Wallet.address)
+        expect(balance).to.equal('999999999999999999999999940')
+      }).timeout(10000)
+
+      // TODO: refactor as reusable behavior
+      describe('ERC677Receiver', () => {
+        it('can transferAndCall from EOA', async () => {
+          // Skip approval
+          const amount = '10'
+
+          const payload = [l2Gateway.address, amount, Buffer.from('')]
+          const transferAndCallTx1 = await l2Token.transferAndCall(...payload)
+          await transferAndCallTx1.wait()
+
+          const transferAndCallTx2 = await l2Token.transferAndCall(...payload)
+          await transferAndCallTx2.wait()
+
+          const transferAndCallTx3 = await l2Token.transferAndCall(...payload)
+          await transferAndCallTx3.wait()
+
+          const balanceWallet = await l2Token.balanceOf(oe.l2Wallet.address)
+          expect(balanceWallet).to.equal('999999999999999999999999910')
+
+          const balanceGateway = await l2Token.balanceOf(l2Gateway.address)
+          expect(balanceGateway).to.equal(0) // all burnt
+        }).timeout(10000)
+
+        it("can't transferAndCall from contract", async () => {
+          const erc677CallerMock = await deploy(
+            _getFactory('ERC677CallerMock', oe.l2Wallet, Versions.v0_7, Targets.OVM),
+            'ERC677CallerMock',
+          )
+
+          // Fund the mock contract
+          const amount = '10'
+          const transferTx = await l2Token.transfer(erc677CallerMock.address, amount)
+          await transferTx.wait()
+
+          // Mock contract tries (fails) to transferAndCall to L1 Gateway
+          const payload = [l2Token.address, l2Gateway.address, amount, Buffer.from('')]
+          const callTransferAndCallTx = erc677CallerMock.callTransferAndCall(...payload)
+          await expect(callTransferAndCallTx).to.be.revertedWith('Account not EOA')
+        })
+      }).timeout(10000)
+
+      it("can't call onTokenTransfer directly", async () => {
+        const amount = '10'
+        const payload = [oe.l2Wallet.address, amount, Buffer.from('')]
+        const onTokenTransferTx = l2Gateway.onTokenTransfer(...payload)
+        await expect(onTokenTransferTx).to.be.revertedWith('onTokenTransfer sender not valid')
+      })
+    })
+  })
+})

--- a/test/v0.7/bridge/optimism/deposit-withdraw.test.ts
+++ b/test/v0.7/bridge/optimism/deposit-withdraw.test.ts
@@ -1,0 +1,57 @@
+import { BigNumberish } from '@ethersproject/bignumber'
+import { parseEther } from '@ethersproject/units'
+import { expect } from 'chai'
+import { depositAndWithdraw, CheckBalances } from '../../../../scripts/deposit-withdraw'
+import { optimism } from '../../../../src'
+import * as h from '../../../helpers'
+
+h.describes().OE('Optimism deposit-withdraw @integration', () => {
+  let oe: optimism.env.OptimismEnv
+
+  before(async function () {
+    this.timeout(10000)
+
+    // Load the configuration from environment
+    oe = await h.optimism.loadEnv()
+    // Fund L2 wallet
+    await oe.depositL2(parseEther('1') as BigNumberish)
+  })
+
+  const checkBalances = (step = 0): CheckBalances => async (
+    l1Wallet,
+    l1ERC20,
+    l2Wallet,
+    l2ERC20,
+  ) => {
+    const _expect = async (_l1Balance: string, _l2Balance: string) => {
+      const l1Balance = await l1ERC20.balanceOf(l1Wallet.address)
+      expect(l1Balance).to.equal(_l1Balance)
+
+      const l2Balance = await l2ERC20.balanceOf(l2Wallet.address)
+      expect(l2Balance).to.equal(_l2Balance)
+    }
+
+    switch (step++) {
+      case 0:
+        return await _expect('1000000000000000000000000000', '0')
+      case 1:
+        return await _expect('999999999999999999999999999', '1')
+      case 2:
+        return await _expect('1000000000000000000000000000', '0')
+      default:
+        expect(step).to.be.lte(3)
+    }
+  }
+
+  describe('deposit L1->L2, withdraw L2->L1', () => {
+    it('approve/transferFrom ', async () => {
+      await depositAndWithdraw(oe, checkBalances())
+    }).timeout(60000)
+
+    it('transferAndCall', async () => {
+      const amount = 1
+      const transferAndCall = true
+      await depositAndWithdraw(oe, checkBalances(), amount, transferAndCall)
+    }).timeout(60000)
+  })
+})

--- a/test/v0.7/bridge/token/LinkTokenChild.test.ts
+++ b/test/v0.7/bridge/token/LinkTokenChild.test.ts
@@ -63,7 +63,7 @@ const EXTRA_PUBLIC_ABI = [
 ]
 
 describe(`LinkTokenChild ${Versions.v0_7}`, () => {
-  h.describes.HH(`@unit ${Versions.v0_7}`, () => {
+  h.describes().HH(`@unit ${Versions.v0_7}`, () => {
     const _getContractFactory = (name: string, signer?: Signer) => {
       if (name === 'LinkToken' || name === 'Token677') {
         return LinkTokenChildTest__factory.new(signer)
@@ -164,7 +164,7 @@ describe(`LinkTokenChild ${Versions.v0_7}`, () => {
     })
   })
 
-  h.describes.OE('@integration', () => {
+  h.describes().OE('@integration', () => {
     let oe: optimism.env.OptimismEnv, l2Token: Contract
 
     before(async function () {


### PR DESCRIPTION
- Add L1 & L2 contracts required for the Optimism token bridge (solc v0.7)
  - Technical details on the token bridge can be found on [Notion |  Optimism OVM (Optimistic Rollup) - Token Bridge](https://www.notion.so/chainlink/Optimism-OVM-Optimistic-Rollup-6e7ef8df83cf4c98af0943f1917e42f5#e70023c416ee4f0a9fc0d1a0672cbf44)
- Make L1/L2 Gateways an `ERC677Receiver` so `transferAndCall` can be used to avoid approving tokens before deposit/withdraw
- Add Optimism integration test
  - L1 -> L2 -> L1 deposit-wihdraw integration test
  - L2 withdrawals safety check integration test (blocking contract withdrawals but allowing EOA contracts to withdraw)
- Expose methods like `deployGateways` to deploy the L1<->L2 bridge that consumers might find useful.
- Add proxy deployment for the bridge contracts (L1 & L2 gateways)
  - Add [@openzeppelin/contracts-upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable), the upgradeable variant of OpenZeppelin Contracts, meant for use in upgradeable contracts.

TODO:

- [ ] Define genesis ProxyEOA.sol codehash in OVM_EOACodeHashSet.sol
- [ ] Document the reasoning behind "unsafe" bridge operations
- [ ] Document upgradebility and bridge extension scenarios
  - [ ] Add deployment scenario (LinkTokenChild first, bridge second) integration  test
- [ ] Get feedback
- [ ] Polish & finalize contracts
- [ ] Audit & approve